### PR TITLE
cleanup and search last_seen_recipes

### DIFF
--- a/lib/chef/knife/preflight.rb
+++ b/lib/chef/knife/preflight.rb
@@ -75,6 +75,7 @@ module KnifePreflight
         if !raw_query.include? "::"
           if type == 'node'
             search_query = "recipes:*#{escaped_query} OR recipes:*#{escaped_query}\\:\\:default"
+            search_query += " OR " + search_query.gsub("recipes", "last_seen_recipes")
           else
             search_query = "run_list:recipe\\[#{escaped_query}\\] OR run_list:recipe\\[#{escaped_query}\\:\\:default\\]"
           end
@@ -82,6 +83,7 @@ module KnifePreflight
         else
           if type == 'node'
             search_query = "recipes:*#{escaped_query}"
+            search_query += " OR " + search_query.gsub("recipes", "last_seen_recipes")
           else
             search_query = "run_list:recipe\\[#{escaped_query}\\]"
           end


### PR DESCRIPTION
few modifications:
- simplify duplicated logic into one function
- simplify the search logic by simply stripping ::default first, then we can tack it back on if the recipe doesn't contain ::  (basically 2 if/else branches instead of 3 now)
- also search the new last_seen_recipes attrib that my handler sticks into the node,  this lets us search for included recipes too
