### PR TITLE
Fix the search query for Chef client 13

### DIFF
--- a/lib/chef/knife/preflight.rb
+++ b/lib/chef/knife/preflight.rb
@@ -27,7 +27,7 @@ module KnifePreflight
     option :sort,
            :short => "-o SORT",
            :long => "--sort SORT",
-           :description => "The order to sort the results in",
+           :description => "The order to sort the results in (only in Chef < 13)",
            :default => nil
 
     option :start,
@@ -103,8 +103,11 @@ module KnifePreflight
 
       rows = config[:rows]
       start = config[:start]
+      args = { start: start, rows: rows }
+      # The sort attribute was removed in Chef 13, only add it on previous versions
+      args[:sort] = config[:sort] if Gem::Version.new(Chef::VERSION) < Gem::Version.new('13.0.0')
       begin
-        q.search(type, query, config[:sort], start, rows) do |item|
+        q.search(type, query, args) do |item|
           formatted_item = format_for_display(item)
           if formatted_item.respond_to?(:has_key?) && !formatted_item.has_key?('id')
             formatted_item.normal['id'] = item.has_key?('id') ? item['id'] : item.name


### PR DESCRIPTION
We had the same issue as in #10 after updating Chef client to 13 (from 12). This PR fixes it. The search API changed in 13, the `sort` argument doesn't exist anymore